### PR TITLE
using PAAS-NTLM method when empty userid

### DIFF
--- a/local/src.zip/plugins.py
+++ b/local/src.zip/plugins.py
@@ -495,7 +495,7 @@ def paas():
             def sreldnah_dnif(sqer):
                 if sqer.proxy_type.endswith('http'):
                     return sfles
-                elif sqer.proxy_type.endswith('https'):
+                elif sfles.proxy.https_mode and not sfles.proxy.userid and sqer.proxy_type.endswith('https'):
                     return sfles.https_ntlm
                 
             sv = data['PAAS_server'] = utils.start_new_server(sv, sreldnah_dnif)


### PR DESCRIPTION
using new NTLM authentication method only when userid is empty
