### PR TITLE
优酷相关的代理项会导致无法观看优酷视频

### DIFF
--- a/local/proxy.ini
+++ b/local/proxy.ini
@@ -42,13 +42,13 @@ iplist =
 rulelist = !rulelist
 ;iplist = !iplist
 [rulelist]
-PROXY api.youku.com:80 = string:///^https?:\/\/.*?(?:youku|qiyi|iqiyi|letv|sohu|ku6|ku6cdn|pps)\.(?:com|tv)\/crossdomain\.xml$/
+;PROXY api.youku.com:80 = string:///^https?:\/\/.*?(?:youku|qiyi|iqiyi|letv|sohu|ku6|ku6cdn|pps)\.(?:com|tv)\/crossdomain\.xml$/
 ;PROXY *:8088;DIRECT = paaslist.ini
 PROXY *:8087;DIRECT = https://autoproxy-gfwlist.googlecode.com/svn/trunk/gfwlist.txt|userlist.ini
 ;PROXY *:8086 = https://adfiltering-rules.googlecode.com/svn/trunk/lastest/rules_for_wallproxy.ini
 
 [py_rulelist]
-YOUKU = string:///^https?:\/\/.*?(?:youku|qiyi|iqiyi|letv|sohu|ku6|ku6cdn|pps)\.(?:com|tv)\/crossdomain\.xml$/
+;YOUKU = string:///^https?:\/\/.*?(?:youku|qiyi|iqiyi|letv|sohu|ku6|ku6cdn|pps)\.(?:com|tv)\/crossdomain\.xml$/
 ;PAAS = paaslist.ini
 GAE = https://autoproxy-gfwlist.googlecode.com/svn/trunk/gfwlist.txt|userlist.ini
 ;PAGE = https://adfiltering-rules.googlecode.com/svn/trunk/lastest/rules_for_wallproxy.ini


### PR DESCRIPTION
必须禁用这两条才行.目前的解决办法似乎是通过Redirects规则让crossdomain.xml转向到本地.
